### PR TITLE
Fix cookies and redirections

### DIFF
--- a/android/src/main/java/onlymash/flexbooru/app/Keys.kt
+++ b/android/src/main/java/onlymash/flexbooru/app/Keys.kt
@@ -16,13 +16,10 @@
 package onlymash.flexbooru.app
 
 object Keys {
-    const val HEADER_COOKIE = "Cookie"
     const val HEADER_USER_AGENT = "User-Agent"
     const val HEADER_REFERER = "Referer"
     const val HEADER_ORIGIN = "Origin"
     const val HEADER_AUTH = "Authorization"
-
-    const val BOORU_TYPE = "booru_type"
 
     const val BOORU_URL = "booru_url"
 

--- a/android/src/main/java/onlymash/flexbooru/data/api/ApiExt.kt
+++ b/android/src/main/java/onlymash/flexbooru/data/api/ApiExt.kt
@@ -32,7 +32,7 @@ import onlymash.flexbooru.okhttp.CloudflareInterceptor
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
 
-fun createHttpClient(isSankaku: Boolean, isGelbooru: Boolean): OkHttpClient {
+fun createHttpClient(isSankaku: Boolean): OkHttpClient {
     val builder = OkHttpClient.Builder()
         .cookieJar(AndroidCookieJar)
         .connectTimeout(15, TimeUnit.SECONDS)
@@ -47,11 +47,6 @@ fun createHttpClient(isSankaku: Boolean, isGelbooru: Boolean): OkHttpClient {
         builder.addInterceptor(ApiSankakuInterceptor())
     } else {
         builder.addInterceptor(ApiInterceptor())
-    }
-
-    if (isGelbooru) {
-        // Gelbooru will return some 302. Do not waste bandwidth to follow it
-        builder.followRedirects(false)
     }
 
     if (Settings.isBypassWAF) {
@@ -96,10 +91,9 @@ inline fun <reified T> createApi(): T {
         }
     }
     val isSankaku = classJava == SankakuApi::class
-    val isGelbooru = classJava == GelbooruApi::class
     return Retrofit.Builder()
         .baseUrl(baseUrl)
-        .client(createHttpClient(isSankaku, isGelbooru))
+        .client(createHttpClient(isSankaku))
         .addConverterFactory(converterFactory)
         .build()
         .create(classJava.java)

--- a/android/src/main/java/onlymash/flexbooru/data/api/GelbooruApi.kt
+++ b/android/src/main/java/onlymash/flexbooru/data/api/GelbooruApi.kt
@@ -17,11 +17,9 @@ package onlymash.flexbooru.data.api
 
 import okhttp3.HttpUrl
 import okhttp3.ResponseBody
-import onlymash.flexbooru.app.Keys
 import onlymash.flexbooru.data.model.gelbooru.*
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.Url
 
 interface GelbooruApi {
@@ -42,8 +40,5 @@ interface GelbooruApi {
     suspend fun getComments(@Url httpUrl: HttpUrl): Response<CommentGelResponse>
 
     @GET
-    suspend fun favPost(
-        @Header(Keys.HEADER_COOKIE) cookie: String? = null,
-        @Url httpUrl: HttpUrl
-    ): Response<ResponseBody>
+    suspend fun favPost(@Url httpUrl: HttpUrl): Response<ResponseBody>
 }

--- a/android/src/main/java/onlymash/flexbooru/data/model/common/User.kt
+++ b/android/src/main/java/onlymash/flexbooru/data/model/common/User.kt
@@ -35,9 +35,6 @@ data class User(
     @SerialName("token_type")
     val tokenType: String = ""
 ) {
-    val gelCookie: String
-        get() = "user_id=$id; pass_hash=$token"
-
     val getAuth: String
         get() = "Bearer $accessToken"
 }

--- a/android/src/main/java/onlymash/flexbooru/data/repository/favorite/VoteRepositoryImpl.kt
+++ b/android/src/main/java/onlymash/flexbooru/data/repository/favorite/VoteRepositoryImpl.kt
@@ -63,8 +63,23 @@ class VoteRepositoryImpl(
                     httpUrl = action.getGelAddFavUrl()
                 )
                 if (response.isSuccessful) {
-                    postDao.updateFav(booruUid = action.booru.uid, postId = action.postId, isFavored = true)
-                    NetResult.Success(true)
+                    val content = response.body()!!.string()
+                    when (content) {
+                        // Success (3) or already in favorites (1)
+                        "3", "1" -> {
+                            postDao.updateFav(booruUid = action.booru.uid, postId = action.postId, isFavored = true)
+                            NetResult.Success(true)
+                        }
+
+                        // Failed
+                        "2" -> {
+                            NetResult.Error("Add to favorites failed")
+                        }
+
+                        else -> {
+                            NetResult.Error("Unknown result")
+                        }
+                    }
                 } else {
                     NetResult.Error("code: ${response.code()}")
                 }

--- a/android/src/main/java/onlymash/flexbooru/okhttp/AndroidCookieJar.kt
+++ b/android/src/main/java/onlymash/flexbooru/okhttp/AndroidCookieJar.kt
@@ -28,6 +28,10 @@ object AndroidCookieJar : CookieJar {
         }
     }
 
+    fun set(url: String, cookies: List<String>) {
+        cookies.forEach { manager.setCookie(url, it) }
+    }
+
     fun remove(url: HttpUrl, cookieNames: List<String>? = null, maxAge: Int = -1): Int {
         val urlString = url.toString()
         val cookies = manager.getCookie(urlString) ?: return 0


### PR DESCRIPTION
1. Rollback HTTP redirection changes. Fix #233.
    Follow redirections will waste 3~10 KB bandwidth (as small as a thumbnail) every time you unfav a pic on a gelbooru-like site, same as in the browser.
2. Fix #238
    Gelbooru sets a cookie named PHPSESSID stored in `AndroidCookieJar`, and it will overwrite user info.
    Solution: import user info cookies to `AndroidCookieJar` too
3. Fix some moeboorus by add special cookies