### PR TITLE
Make downloading videos via ADM toggleable.

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -45,7 +45,7 @@ exec {
 val verCode = String(byteOut.toByteArray()).trim().toInt()
 
 object Configs {
-    const val APP_VERSION_NAME = "3.2.4"
+    const val APP_VERSION_NAME = "3.2.5"
     const val APP_ID = "onlymash.flexbooru.play"
     const val SDK_VERSION = 34
     const val MIN_SDK_VERSION = 21

--- a/android/src/main/java/onlymash/flexbooru/app/Settings.kt
+++ b/android/src/main/java/onlymash/flexbooru/app/Settings.kt
@@ -32,6 +32,7 @@ object Settings {
     const val DISABLE_SNI_KEY = "settings_disable_sni"
     const val BYPASS_WAF_KEY = "settings_bypass_waf"
     const val SAFE_MODE_KEY = "settings_safe_mode"
+    const val DOWNLOAD_VIDEOS_BY_ADM = "settings_download_videos_by_adm"
     const val PAGE_LIMIT_KEY = "settings_page_limit"
     const val MUZEI_LIMIT_KEY = "settings_muzei_limit"
     const val DETAIL_SIZE_KEY = "settings_detail_size"
@@ -91,6 +92,11 @@ object Settings {
         get() = sp.getBoolean(SAFE_MODE_KEY, true)
         set(value) = sp.edit().putBoolean(
             SAFE_MODE_KEY, value).apply()
+
+    var downloadVideosByADM: Boolean
+        get() = sp.getBoolean(DOWNLOAD_VIDEOS_BY_ADM, true)
+        set(value) = sp.edit().putBoolean(
+            DOWNLOAD_VIDEOS_BY_ADM, value).apply()
 
     var pageLimit: Int
         get() = sp.getString(PAGE_LIMIT_KEY, "30")!!.toInt()

--- a/android/src/main/java/onlymash/flexbooru/ui/activity/DetailActivity.kt
+++ b/android/src/main/java/onlymash/flexbooru/ui/activity/DetailActivity.kt
@@ -57,6 +57,7 @@ import onlymash.flexbooru.app.Settings.POST_SIZE_LARGER
 import onlymash.flexbooru.app.Settings.POST_SIZE_SAMPLE
 import onlymash.flexbooru.app.Settings.activatedBooruUid
 import onlymash.flexbooru.app.Settings.detailSize
+import onlymash.flexbooru.app.Settings.downloadVideosByADM
 import onlymash.flexbooru.app.Values.BOORU_TYPE_DAN
 import onlymash.flexbooru.app.Values.BOORU_TYPE_DAN1
 import onlymash.flexbooru.app.Values.BOORU_TYPE_GEL
@@ -429,7 +430,7 @@ class DetailActivity : PathActivity(),
     }
 
     private fun download(post: Post) {
-        if (post.origin.isVideo()) {
+        if (post.origin.isVideo() && downloadVideosByADM) {
             downloadByAdm(post.origin)
         } else {
             DownloadWorker.downloadPost(post, booru.host, this)

--- a/android/src/main/java/onlymash/flexbooru/ui/fragment/PostFragment.kt
+++ b/android/src/main/java/onlymash/flexbooru/ui/fragment/PostFragment.kt
@@ -58,6 +58,7 @@ import onlymash.flexbooru.app.Settings.PAGE_LIMIT_KEY
 import onlymash.flexbooru.app.Settings.SAFE_MODE_KEY
 import onlymash.flexbooru.app.Settings.SHOW_ALL_TAGS_KEY
 import onlymash.flexbooru.app.Settings.SHOW_INFO_BAR_KEY
+import onlymash.flexbooru.app.Settings.downloadVideosByADM
 import onlymash.flexbooru.app.Settings.gridMode
 import onlymash.flexbooru.app.Settings.gridRatio
 import onlymash.flexbooru.app.Settings.gridWidthResId
@@ -393,7 +394,7 @@ class PostFragment : SearchBarFragment() {
                 when (which) {
                     0 -> {
                         action?.apply {
-                            if (post.origin.isVideo()) {
+                            if (post.origin.isVideo() && downloadVideosByADM) {
                                 context?.downloadByAdm(post.origin)
                             } else {
                                 DownloadWorker.downloadPost(post, booru.host, activity)

--- a/android/src/main/java/onlymash/flexbooru/ui/fragment/ShortcutInfoFragment.kt
+++ b/android/src/main/java/onlymash/flexbooru/ui/fragment/ShortcutInfoFragment.kt
@@ -26,6 +26,7 @@ import androidx.core.content.ContextCompat
 import coil.load
 import onlymash.flexbooru.R
 import onlymash.flexbooru.app.Keys
+import onlymash.flexbooru.app.Settings
 import onlymash.flexbooru.app.Values
 import onlymash.flexbooru.data.model.common.Booru
 import onlymash.flexbooru.data.model.common.Post
@@ -178,7 +179,7 @@ class ShortcutInfoFragment : ShortcutFragment<FragmentShortcutInfoBinding>() {
         val post = post ?: return
         val activity = activity as? PathActivity ?: return
         val url = getUrl(post, type)
-        if (url.isVideo()) {
+        if (url.isVideo() && Settings.downloadVideosByADM) {
             context?.downloadByAdm(url)
         } else {
             DownloadWorker.download(

--- a/android/src/main/res/values-bn-rBD/strings.xml
+++ b/android/src/main/res/values-bn-rBD/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Safe mode</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Page limit</string>
     <string name="settings_muzei_limit">Muzei limit</string>
     <string name="settings_muzei_size">Muzei size</string>

--- a/android/src/main/res/values-de-rDE/strings.xml
+++ b/android/src/main/res/values-de-rDE/strings.xml
@@ -177,6 +177,7 @@
     <string name="settings_bypass_waf">WAF umgehen</string>
     <string name="settings_bypass_waf_summary">Cloudflare WAF umgehen</string>
     <string name="settings_safe_mode">Sicherer Modus</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Seitenlimit</string>
     <string name="settings_muzei_limit">Muzei Limit</string>
     <string name="settings_muzei_size">Bildergröße (Muzei)</string>

--- a/android/src/main/res/values-es-rES/strings.xml
+++ b/android/src/main/res/values-es-rES/strings.xml
@@ -177,6 +177,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Modo seguro</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Límite de páginas</string>
     <string name="settings_muzei_limit">Límite Muzei</string>
     <string name="settings_muzei_size">Tamaño de Muzei</string>

--- a/android/src/main/res/values-fr-rFR/strings.xml
+++ b/android/src/main/res/values-fr-rFR/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Mode sécurisé</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Limite de page</string>
     <string name="settings_muzei_limit">Limite du Muzei</string>
     <string name="settings_muzei_size">Taille du Muzei</string>

--- a/android/src/main/res/values-hi-rIN/strings.xml
+++ b/android/src/main/res/values-hi-rIN/strings.xml
@@ -177,6 +177,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Safe mode</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Page limit</string>
     <string name="settings_muzei_limit">Muzei limit</string>
     <string name="settings_muzei_size">Muzei size</string>

--- a/android/src/main/res/values-hu-rHU/strings.xml
+++ b/android/src/main/res/values-hu-rHU/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Safe mode</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Oldal limit</string>
     <string name="settings_muzei_limit">Muzei limit</string>
     <string name="settings_muzei_size">Muzei méret</string>

--- a/android/src/main/res/values-in-rID/strings.xml
+++ b/android/src/main/res/values-in-rID/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Mode aman</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Batas halaman</string>
     <string name="settings_muzei_limit">Batas Muzei</string>
     <string name="settings_muzei_size">Ukuran muzei</string>

--- a/android/src/main/res/values-ja-rJP/strings.xml
+++ b/android/src/main/res/values-ja-rJP/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">WAFを回避する</string>
     <string name="settings_bypass_waf_summary">CloudflareのWAFを回避する</string>
     <string name="settings_safe_mode">セーフモード</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">ページ制限</string>
     <string name="settings_muzei_limit">Muzei制限</string>
     <string name="settings_muzei_size">Muzeiサイズ</string>

--- a/android/src/main/res/values-nl-rNL/strings.xml
+++ b/android/src/main/res/values-nl-rNL/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Veilige modus</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Paginalimiet</string>
     <string name="settings_muzei_limit">Muzeilimiet</string>
     <string name="settings_muzei_size">Muzeigrootte</string>

--- a/android/src/main/res/values-pl-rPL/strings.xml
+++ b/android/src/main/res/values-pl-rPL/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Pomiń WAF</string>
     <string name="settings_bypass_waf_summary">Pomijanie WAF Cloudflare</string>
     <string name="settings_safe_mode">Tryb bezpieczny</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Limit strony</string>
     <string name="settings_muzei_limit">Limit Muzei</string>
     <string name="settings_muzei_size">Rozmiar Muzei</string>

--- a/android/src/main/res/values-pt-rBR/strings.xml
+++ b/android/src/main/res/values-pt-rBR/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Modo seguro</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Limite de página</string>
     <string name="settings_muzei_limit">Limite de Muzei</string>
     <string name="settings_muzei_size">Tamanho do Muzei</string>

--- a/android/src/main/res/values-ru-rRU/strings.xml
+++ b/android/src/main/res/values-ru-rRU/strings.xml
@@ -177,6 +177,7 @@
     <string name="settings_bypass_waf">Обход WAF</string>
     <string name="settings_bypass_waf_summary">Обходит Cloudflare WAF</string>
     <string name="settings_safe_mode">Безопасный режим</string>
+    <string name="settings_download_videos_by_adm">Скачивать видео через ADM</string>
     <string name="settings_page_limit">Лимит страниц</string>
     <string name="settings_muzei_limit">Лимит Muzei</string>
     <string name="settings_muzei_size">Размер музея</string>

--- a/android/src/main/res/values-th-rTH/strings.xml
+++ b/android/src/main/res/values-th-rTH/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Safe mode</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Page limit</string>
     <string name="settings_muzei_limit">Muzei limit</string>
     <string name="settings_muzei_size">Muzei size</string>

--- a/android/src/main/res/values-tr-rTR/strings.xml
+++ b/android/src/main/res/values-tr-rTR/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">WAF\'ı bypass et</string>
     <string name="settings_bypass_waf_summary">Cloudflare WAF\'ı bypass etme</string>
     <string name="settings_safe_mode">Güvenli mod</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Sayfa sınırı</string>
     <string name="settings_muzei_limit">Muzei sınırı</string>
     <string name="settings_muzei_size">Muzei boyutu</string>

--- a/android/src/main/res/values-zh-rCN/strings.xml
+++ b/android/src/main/res/values-zh-rCN/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">绕过 WAF</string>
     <string name="settings_bypass_waf_summary">绕过 Cloudflare WAF</string>
     <string name="settings_safe_mode">安全模式</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">每页限制</string>
     <string name="settings_muzei_limit">Muzei 限制</string>
     <string name="settings_muzei_size">Muzei 大小</string>

--- a/android/src/main/res/values-zh-rHK/strings.xml
+++ b/android/src/main/res/values-zh-rHK/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">略過 WAF</string>
     <string name="settings_bypass_waf_summary">略過 Cloudflare WAF</string>
     <string name="settings_safe_mode">安全模式</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">每頁限制</string>
     <string name="settings_muzei_limit">Muzei 限制</string>
     <string name="settings_muzei_size">Muzei 大小</string>

--- a/android/src/main/res/values-zh-rTW/strings.xml
+++ b/android/src/main/res/values-zh-rTW/strings.xml
@@ -176,6 +176,7 @@
     <string name="settings_bypass_waf">略過 WAF</string>
     <string name="settings_bypass_waf_summary">略過 Cloudflare WAF</string>
     <string name="settings_safe_mode">安全模式</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">每頁限制</string>
     <string name="settings_muzei_limit">Muzei 限制</string>
     <string name="settings_muzei_size">Muzei 影像大小</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
     <string name="settings_bypass_waf">Bypass WAF</string>
     <string name="settings_bypass_waf_summary">Bypassing Cloudflare WAF</string>
     <string name="settings_safe_mode">Safe mode</string>
+    <string name="settings_download_videos_by_adm">Download videos by ADM</string>
     <string name="settings_page_limit">Page limit</string>
     <string name="settings_muzei_limit">Muzei limit</string>
     <string name="settings_muzei_size">Muzei size</string>

--- a/android/src/main/res/xml/pref_settings.xml
+++ b/android/src/main/res/xml/pref_settings.xml
@@ -137,6 +137,13 @@
             app:summaryOn="@string/switch_on"
             app:summaryOff="@string/switch_off"/>
 
+        <SwitchPreferenceCompat
+            app:key="settings_download_videos_by_adm"
+            app:title="@string/settings_download_videos_by_adm"
+            app:defaultValue="true"
+            app:summaryOn="@string/switch_on"
+            app:summaryOff="@string/switch_off"/>
+
         <ListPreference
             app:key="settings_page_limit"
             app:entries="@array/settings_page_limit_entries"


### PR DESCRIPTION
I personally don't want to install a separate app just to download hentai videos from boorus, so I'd prefer making ADM optional.
Especially, when the downloading worked perfectly for me before.
The issue with downloading only the thumbnail (if that was actually the reason behind making ADM a default setting) can be fixed by changing detail image size to Original. I understand this may not be suitable for everyone, so ADM is On by default in this PR.